### PR TITLE
Add missing includes

### DIFF
--- a/src/render.cpp
+++ b/src/render.cpp
@@ -6,6 +6,7 @@
 
 #include <SDL2/SDL_image.h>
 
+#include <cstring>
 #include <memory>
 
 using SdlSurface = std::unique_ptr<SDL_Surface, decltype(&SDL_FreeSurface)>;

--- a/src/skin.cpp
+++ b/src/skin.cpp
@@ -9,6 +9,8 @@
 #include <SDL2/SDL_image.h>
 #include <dirent.h>
 
+#include <cstring>
+
 SDL_Surface* Skin::initialize(const std::string& name)
 {
     SDL_Surface* image = nullptr;

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -8,6 +8,7 @@
 
 #include <SDL2/SDL.h>
 
+#include <cstring>
 #include <string>
 
 Sound::~Sound()

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -6,6 +6,7 @@
 
 #include <SDL2/SDL.h>
 
+#include <cstring>
 #include <vector>
 
 #include "level.hpp"


### PR DESCRIPTION
- `src/render.cpp` requires `<cstring>` for `strlen()` and `strcmp()` calls
- `src/skin.cpp` requires `<cstring>` for `malloc()` calls
- `src/sound.cpp` requires `<cstring>` for `malloc()` calls
- `src/state.cpp` requires `<cstring>` for `strlen()` calls